### PR TITLE
Add a retry loop around tagging the instance

### DIFF
--- a/cmd/pudding-workers/main.go
+++ b/cmd/pudding-workers/main.go
@@ -120,6 +120,8 @@ func runWorkers(c *cli.Context) {
 
 		InstanceRSA:        instanceRSA,
 		InstanceYML:        instanceYML,
+		InstanceTagRetries: 10,
+
 		InitScriptTemplate: initScriptTemplate,
 		MiniWorkerInterval: c.Int("mini-worker-interval"),
 		InstanceExpiry:     c.Int("instance-expiry"),

--- a/lib/workers/config.go
+++ b/lib/workers/config.go
@@ -16,6 +16,8 @@ type Config struct {
 
 	InstanceRSA        string
 	InstanceYML        string
+	InstanceTagRetries int
+
 	InitScriptTemplate string
 	MiniWorkerInterval int
 	InstanceExpiry     int

--- a/lib/workers/instance_builds.go
+++ b/lib/workers/instance_builds.go
@@ -121,8 +121,15 @@ func (ibw *instanceBuilderWorker) Build() error {
 
 	ibw.b.InstanceID = ibw.i.InstanceId
 
-	log.WithField("jid", ibw.jid).Debug("tagging instance")
-	err = ibw.tagInstance()
+	for i := ibw.cfg.InstanceTagRetries; i > 0; i-- {
+		log.WithField("jid", ibw.jid).Debug("tagging instance")
+		err = ibw.tagInstance()
+		if err == nil {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"err": err,

--- a/lib/workers/internal_config.go
+++ b/lib/workers/internal_config.go
@@ -24,8 +24,9 @@ type internalConfig struct {
 	WebHost   string
 	ProcessID string
 
-	InstanceRSA string
-	InstanceYML string
+	InstanceRSA        string
+	InstanceYML        string
+	InstanceTagRetries int
 
 	Queues             []string
 	QueueFuncs         map[string]func(*internalConfig, *workers.Msg)

--- a/lib/workers/main.go
+++ b/lib/workers/main.go
@@ -29,8 +29,9 @@ func Main(cfg *Config) {
 		WebHost:   cfg.WebHostname,
 		ProcessID: cfg.ProcessID,
 
-		InstanceRSA: cfg.InstanceRSA,
-		InstanceYML: cfg.InstanceYML,
+		InstanceRSA:        cfg.InstanceRSA,
+		InstanceYML:        cfg.InstanceYML,
+		InstanceTagRetries: cfg.InstanceTagRetries,
 
 		Queues:             []string{},
 		QueueConcurrencies: map[string]int{},


### PR DESCRIPTION
to get around a seeming race condition that results in instances being started and doing work, yet remaining invisible to the hubot-pudding list commands.
